### PR TITLE
Fix for crashes that got introduced by moving statistics calc to background thread

### DIFF
--- a/xdrip/Utilities/HouseKeeping/HouseKeeper.swift
+++ b/xdrip/Utilities/HouseKeeping/HouseKeeper.swift
@@ -84,6 +84,8 @@ class HouseKeeper {
             
             bgReadingsAccessor.delete(bgReading: oldReading, on: managedObjectContext)
             
+            coreDataManager.saveChanges()
+            
         }
         
     }
@@ -110,6 +112,8 @@ class HouseKeeper {
             } else {
 
                 calibrationsAccessor.delete(calibration: oldCalibration, on: managedObjectContext)
+                
+                coreDataManager.saveChanges()
 
             }
             

--- a/xdrip/View Controllers/Root View Controller/RootViewController.swift
+++ b/xdrip/View Controllers/Root View Controller/RootViewController.swift
@@ -733,6 +733,8 @@ final class RootViewController: UIViewController {
                     
                     coreDataManager.mainManagedObjectContext.delete(reading)
                     
+                    coreDataManager.saveChanges()
+                    
                 }
                 
                 // as we're deleting readings, glucoseChartPoints need to be updated, otherwise we keep seeing old values


### PR DESCRIPTION
The crashes were due to the background thread that was using BgReading instances on a private managed object context, however those BgReadings were already deleted in the main managed object context, but without saving.
There's no a save to core data done immediately after deleting a BgReading, this seems to fix the crashes